### PR TITLE
fixing 'no contracts' duplicate call

### DIFF
--- a/assets/js/logic.js
+++ b/assets/js/logic.js
@@ -29,9 +29,6 @@ function deleteRow(i) {
         if (willDelete) {
             const allContractsData = readContractsData();
             allContractsData.splice(i, 1);
-            if (allContractsData.length === 0) {
-                noContracts();
-            }
             localStorage.setItem('allContractsData', JSON.stringify(allContractsData));
             renderContractList();
             swal("The contract has been deleted!", {


### PR DESCRIPTION
When a user deleted the last contract in the table, the console would log two messages saying there were no contracts in local storage. This fixes it so that message only displays once.